### PR TITLE
fix(scheduling): correct caption data parameter mismatch

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2186,8 +2186,8 @@
                     body: JSON.stringify({
                         imageId: currentImageId,
                         imageHash: currentImageHash,
-                        caption: customCaption || generatedCaption,
-                        hashtags: customHashtags || generatedHashtags,
+                        customCaption: customCaption || generatedCaption,
+                        customHashtags: customHashtags || generatedHashtags,
                         platforms: selectedPlatforms,
                         scheduledTime: scheduledTime.toISOString(),
                         timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,


### PR DESCRIPTION
- Fix frontend to send 'customCaption' instead of 'caption' parameter
- Resolves issue where scheduled posts displayed "Scheduled post" fallback text
- Ensures actual generated caption content is properly saved and displayed

Fixes the parameter mismatch between frontend and backend API